### PR TITLE
Fix ffmpeg dependency

### DIFF
--- a/CI/build-macos.sh
+++ b/CI/build-macos.sh
@@ -5,6 +5,7 @@ set -ex
 
 mkdir build && cd build
 cmake .. \
+  -DDepsPath=/tmp/obsdeps \
   -DQTDIR=/usr/local/opt/qt \
   -DLIBOBS_INCLUDE_DIR=../../obs-studio/libobs \
   -DLIBOBS_LIB=../../obs-studio/libobs \

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -10,12 +10,18 @@ brew install libav
 # what was used to build OBS Studio. Right now it was 3.4.2, so I created
 # a homebrew tap that points to that version.
 #brew install ffmpeg # installs version 4.
-if brew ls --versions ffmpeg > /dev/null; then
-  brew uninstall ffmpeg
-fi
+#if brew ls --versions ffmpeg > /dev/null; then
+#  brew uninstall ffmpeg
+#fi
 
-brew tap wtsnz/brew-ffmpeg-tap https://github.com/wtsnz/brew-ffmpeg-tap.git
-brew install wtsnz/brew-ffmpeg-tap/ffmpeg
+
+# Fetch and untar prebuilt OBS deps that are compatible with older versions of OSX
+echo "Downloading OBS deps"
+wget --quiet --retry-connrefused --waitretry=1 https://s3-us-west-2.amazonaws.com/obs-nightly/osx-deps.tar.gz
+tar -xf ./osx-deps.tar.gz -C /tmp
+
+#brew tap wtsnz/brew-ffmpeg-tap https://github.com/wtsnz/brew-ffmpeg-tap.git
+#brew install wtsnz/brew-ffmpeg-tap/ffmpeg
 
 # qtwebsockets deps
 # qt latest
@@ -28,16 +34,24 @@ brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/2b121c9a96
 
 # Build obs-studio
 cd ..
-git clone --recursive https://github.com/jp9000/obs-studio
+git clone https://github.com/obsproject/obs-studio
 cd obs-studio
-git checkout 21.0.0
+OBSLatestTag=$(git describe --tags --abbrev=0)
+git checkout $OBSLatestTag
 mkdir build && cd build
 cmake .. \
+  -DDepsPath=/tmp/obsdeps \
+  -DDISABLE_PLUGINS=true \
   -DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake \
 && make -j4
 
 # Packages app
 cd ..
-curl -L -O  http://s.sudre.free.fr/Software/files/Packages.dmg -f --retry 5 -C -
-hdiutil attach ./Packages.dmg
-sudo installer -pkg /Volumes/Packages\ 1.2.3/packages/Packages.pkg -target /
+# curl -L -O  http://s.sudre.free.fr/Software/files/Packages.dmg -f --retry 5 -C -
+# hdiutil attach ./Packages.dmg
+# sudo installer -pkg /Volumes/Packages\ 1.2.3/packages/Packages.pkg -target /
+
+
+# Packages app
+wget --quiet --retry-connrefused --waitretry=1 https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg
+sudo installer -pkg ./Packages.pkg -target /

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -10,6 +10,12 @@ brew install libav
 # what was used to build OBS Studio. Right now it was 3.4.2, so I created
 # a homebrew tap that points to that version.
 #brew install ffmpeg # installs version 4.
+if brew ls --versions ffmpeg > /dev/null; then
+  brew uninstall ffmpeg
+else
+  # The package is not installed
+fi
+
 brew tap wtsnz/brew-ffmpeg-tap https://github.com/wtsnz/brew-ffmpeg-tap.git
 brew install wtsnz/brew-ffmpeg-tap/ffmpeg
 

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -3,7 +3,7 @@ set -ex
 
 # OBS Studio deps
 brew update
-brew install ffmpeg
+# brew install ffmpeg
 brew install libav
 
 # We need to make sure that the version of FFMpeg is the same as
@@ -12,8 +12,6 @@ brew install libav
 #brew install ffmpeg # installs version 4.
 if brew ls --versions ffmpeg > /dev/null; then
   brew uninstall ffmpeg
-else
-  # The package is not installed
 fi
 
 brew tap wtsnz/brew-ffmpeg-tap https://github.com/wtsnz/brew-ffmpeg-tap.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ include(external/FindLibObs.cmake)
 
 find_package(LibObs REQUIRED)
 
+find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil)
+# find_ffmpeg_library(avcodec)
+# find_ffmpeg_library(avutil)
+
 if(WIN32)
 	find_library(WS2_32_LIBRARY ws2_32)
 endif()
@@ -222,7 +226,7 @@ add_library(obs-ios-camera-source MODULE
 	${obs-ios-camera-source_HEADERS})
 
 
-find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil)
+#find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil)
 
 include_directories( 
 	"${LIBOBS_INCLUDE_DIR}/../UI/obs-frontend-api"

--- a/README.md
+++ b/README.md
@@ -17,5 +17,13 @@ To use this you use the [accompanying iOS app](https://will.townsend.io/products
 
 Binaries for Windows and Mac are available in the [Releases](https://github.com/wtsnz/obs-ios-camera-source/releases) section.
 
+## Building
+
+You can run the CI scripts to build it. They will clone and build OBS Studio prior to building this plugin.
+
+    ./CI/install-dependencies-macos.sh
+    ./CI/build-macos.sh
+    ./CI/package-macos.sh
+
 ## Special thanks
 - The entire [obs-websockets](https://github.com/Palakis/obs-websocket) project for providing a stella example of an obs plugin build pipeline!


### PR DESCRIPTION
Whoops, V2.0.0 installs version 4.0.0 of ffpmeg which isn't the same as OBS Studio.

This makes the plugin fail to load on OSX, after installed from the installer.