### PR TITLE
Add audio decoder queue

### DIFF
--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -25,10 +25,10 @@ tar -xf ./osx-deps.tar.gz -C /tmp
 
 # qtwebsockets deps
 # qt latest
-#brew install qt5
+brew install qt5
 
 # qt 5.9.2
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/2b121c9a96e58a5da14228630cb71d5bead7137e/Formula/qt.rb
+#brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/2b121c9a96e58a5da14228630cb71d5bead7137e/Formula/qt.rb
 
 #echo "Qt path: $(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ set(obs-ios-camera-source_SOURCES
 	src/ffmpeg-decode.c
 	src/VideoDecoder.cpp
 	src/FFMpegVideoDecoder.cpp
+	src/FFMpegAudioDecoder.cpp
 	src/Thread.cpp)
 
 set(obs-ios-camera-source_HEADERS
@@ -185,6 +186,7 @@ set(obs-ios-camera-source_HEADERS
 	src/ffmpeg-decode.h
 	src/VideoDecoder.h
 	src/FFMpegVideoDecoder.h
+	src/FFMpegAudioDecoder.h
 	src/Thread.hpp
 	src/Queue.hpp)
 

--- a/src/FFMpegAudioDecoder.cpp
+++ b/src/FFMpegAudioDecoder.cpp
@@ -1,0 +1,133 @@
+
+/*
+ obs-ios-camera-source
+ Copyright (C) 2018    Will Townsend <will@townsend.io>
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License along
+ with this program. If not, see <https://www.gnu.org/licenses/>
+ */
+
+#include "FFMpegAudioDecoder.h"
+#include <util/platform.h>
+#include <fstream>
+
+FFMpegAudioDecoder::FFMpegAudioDecoder()
+{
+    memset(&audio_frame, 0, sizeof(audio_frame));
+}
+
+FFMpegAudioDecoder::~FFMpegAudioDecoder()
+{
+    this->Shutdown();
+    // Free the video decoder.
+    ffmpeg_decode_free(audio_decoder);
+}
+
+void FFMpegAudioDecoder::Init()
+{
+    // Start the thread.
+    this->start();
+}
+
+void FFMpegAudioDecoder::Flush()
+{
+    // Clear the queue
+}
+
+void FFMpegAudioDecoder::Drain()
+{
+    // Drain the queue
+}
+
+void FFMpegAudioDecoder::Shutdown()
+{
+    mQueue.stop();
+    this->join();
+}
+
+void FFMpegAudioDecoder::Input(std::vector<char> packet, int type, int tag)
+{
+    // Create a new packet item and enqueue it.
+    PacketItem *item = new PacketItem(packet, type, tag);
+    this->mQueue.add(item);
+}
+
+void FFMpegAudioDecoder::processPacketItem(PacketItem *packetItem)
+{
+    
+    if (!ffmpeg_decode_valid(audio_decoder))
+    {
+        if (ffmpeg_decode_init(audio_decoder, AV_CODEC_ID_AAC) < 0)
+        {
+            blog(LOG_WARNING, "Could not initialize audio decoder");
+            return;
+        }
+    }
+    
+    auto packet = packetItem->getPacket();
+    unsigned char *data = (unsigned char *)packet.data();
+    long long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    
+    if (packetItem->getType() == 102) {
+        
+        bool got_output;
+        
+        bool success = ffmpeg_decode_audio(audio_decoder, data, packet.size(), &audio_frame, &got_output);
+        
+        if (!success)
+        {
+            blog(LOG_WARNING, "Error decoding audio");
+            return;
+        }
+        
+        if (got_output && source != NULL)
+        {
+            audio_frame.timestamp = os_gettime_ns() - 100000000; // -100ms
+            obs_source_output_audio(source, &audio_frame);
+        }
+        
+    }
+    
+}
+
+void *FFMpegAudioDecoder::run() {
+    
+    while (shouldStop() == false) {
+        
+        PacketItem *item = (PacketItem *)mQueue.remove();
+        
+        if (item != NULL) {
+            this->processPacketItem(item);
+            delete item;
+        }
+        
+        // Check queue lengths
+        
+        const int queueSize = mQueue.size();
+        if (queueSize > 25) {
+            blog(LOG_WARNING, "Audio Decoding queue overloaded. %d frames behind. Please use a lower quality setting.", queueSize);
+            
+            if (queueSize > 25) {
+                while (mQueue.size() > 5) {
+                    mQueue.remove();
+                }
+            }
+            
+        }
+        
+    }
+    
+    return NULL;
+}
+
+

--- a/src/FFMpegAudioDecoder.h
+++ b/src/FFMpegAudioDecoder.h
@@ -1,0 +1,72 @@
+/*
+ obs-ios-camera-source
+ Copyright (C) 2018    Will Townsend <will@townsend.io>
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License along
+ with this program. If not, see <https://www.gnu.org/licenses/>
+ */
+
+#include <chrono>
+
+#include "obs-ios-camera-source.h"
+#include "VideoDecoder.h"
+#include "ffmpeg-decode.h"
+#include "Queue.hpp"
+#include "Thread.hpp"
+
+class AudioDecoder
+{
+    struct ffmpeg_decode decode;
+    
+public:
+    inline AudioDecoder() { memset(&decode, 0, sizeof(decode)); }
+    inline ~AudioDecoder() { ffmpeg_decode_free(&decode); }
+    
+    inline operator ffmpeg_decode *() { return &decode; }
+    inline ffmpeg_decode *operator->() { return &decode; }
+};
+
+class FFMpegAudioDecoderCallback {
+public:
+    virtual ~FFMpegAudioDecoderCallback() {}
+};
+
+class FFMpegAudioDecoder: public VideoDecoder, private Thread
+{
+public:
+    FFMpegAudioDecoder();
+    ~FFMpegAudioDecoder();
+    
+    void Init() override;
+    
+    void Input(std::vector<char> packet, int type, int tag) override;
+    
+    void Flush() override;
+    void Drain() override;
+    void Shutdown() override;
+    
+    obs_source_t *source;
+    
+private:
+    
+    void *run() override;
+    
+    void processPacketItem(PacketItem *packetItem);
+    
+    WorkQueue<PacketItem *> mQueue;
+    
+    obs_source_audio audio_frame;
+    
+    AudioDecoder audio_decoder;
+    
+};

--- a/src/FFMpegVideoDecoder.h
+++ b/src/FFMpegVideoDecoder.h
@@ -39,8 +39,6 @@ public:
 class FFMpegVideoDecoderCallback {
 public:
     virtual ~FFMpegVideoDecoderCallback() {}
-    
-//    virtual void VideoToolboxDecodedFrame(CVPixelBufferRef aImage, CMVideoFormatDescriptionRef formatDescription) = 0;
 };
 
 class FFMpegVideoDecoder: public VideoDecoder, private Thread
@@ -68,9 +66,7 @@ private:
     WorkQueue<PacketItem *> mQueue;
     
     obs_source_frame video_frame;
-    obs_source_audio audio_frame;
     
     Decoder video_decoder;
-    Decoder audio_decoder;
     
 };

--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.2.0"
+#define IOS_CAMERA_PLUGIN_VERSION "2.2.2"
 
 extern void RegisterIOSCameraSource();
 


### PR DESCRIPTION
This PR adds another audio decoder class based off FFmpeg. 

This fixes glitches in the audio when frames take longer to decode that the audio samples. Rather than decoding both audio and video samples on the same queue, it's now done on their respective queues.