### PR TITLE
Add support for converting YUVJ420P pixel formats

### DIFF
--- a/src/ffmpeg-decode.c
+++ b/src/ffmpeg-decode.c
@@ -82,6 +82,8 @@ static inline enum video_format convert_pixel_format(int f)
 		return VIDEO_FORMAT_BGRA;
 	case AV_PIX_FMT_BGR0:
 		return VIDEO_FORMAT_BGRX;
+    case AV_PIX_FMT_YUVJ420P:
+        return VIDEO_FORMAT_I420;
 	default:;
 	}
 


### PR DESCRIPTION
This allows the decoder to decode the format that is encoded from the iOS Broadcast Extension