### PR TITLE
Update dependencies for OBS v22.0.1 on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ deploy:
     tags: true
 addons:
   artifacts:
+    s3_region: "us-west-1"
     debug: true
     paths:
     - $(ls release/* | tr "\n" ":")

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,9 @@ deploy:
   on:
     repo: wtsnz/obs-ios-camera-source
     tags: true
-    
+addons:
+  artifacts:
+    debug: true
+    paths:
+    - $(ls release/* | tr "\n" ":")
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ deploy:
   on:
     repo: wtsnz/obs-ios-camera-source
     tags: true
+
 addons:
   artifacts:
     debug: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ deploy:
     tags: true
 addons:
   artifacts:
-    s3_region: "us-west-1"
     debug: true
     paths:
     - $(ls release/* | tr "\n" ":")

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -17,8 +17,9 @@ brew install libav
 
 # Fetch and untar prebuilt OBS deps that are compatible with older versions of OSX
 echo "Downloading OBS deps"
-wget --quiet --retry-connrefused --waitretry=1 https://s3-us-west-2.amazonaws.com/obs-nightly/osx-deps.tar.gz
-tar -xf ./osx-deps.tar.gz -C /tmp
+
+wget --quiet --retry-connrefused --waitretry=1 https://obs-nightly.s3.amazonaws.com/osx-deps-2018-08-09.tar.gz
+tar -xf ./osx-deps-2018-08-09.tar.gz -C /tmp
 
 #brew tap wtsnz/brew-ffmpeg-tap https://github.com/wtsnz/brew-ffmpeg-tap.git
 #brew install wtsnz/brew-ffmpeg-tap/ffmpeg

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -19,10 +19,10 @@ export LATEST_FILENAME="obs-ios-camera-source-latest-$LATEST_VERSION.pkg"
 
 echo "-- Modifying obs-ios-camera-source.so"
 install_name_tool \
-	-change /usr/local/opt/ffmpeg/lib/libavcodec.57.dylib @rpath/libavcodec.57.dylib \
-	-change /usr/local/opt/ffmpeg/lib/libavutil.55.dylib @rpath/libavutil.55.dylib \
-	-change /tmp/obsdeps/bin/libavcodec.57.dylib @rpath/libavcodec.57.dylib \
-	-change /tmp/obsdeps/bin/libavutil.55.dylib @rpath/libavutil.55.dylib \
+	-change /usr/local/opt/ffmpeg/lib/libavcodec.58.dylib @rpath/libavcodec.58.dylib \
+	-change /usr/local/opt/ffmpeg/lib/libavutil.56.dylib @rpath/libavutil.56.dylib \
+	-change /tmp/obsdeps/bin/libavcodec.58.dylib @rpath/libavcodec.58.dylib \
+	-change /tmp/obsdeps/bin/libavutil.56.dylib @rpath/libavutil.56.dylib \
 	./build/obs-ios-camera-source.so
 
 echo "-- Dependencies for obs-ios-camera-source"

--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.3.1"
+#define IOS_CAMERA_PLUGIN_VERSION "2.3.2"
 
 extern void RegisterIOSCameraSource();
 


### PR DESCRIPTION
The new version of OBS Studio has updated the ffmpeg version. We need to update the references to the dylibs.