### PR TITLE
Fix: Prevent reconnecting to connected device

### DIFF
--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.5.1"
+#define IOS_CAMERA_PLUGIN_VERSION "2.5.2"
 
 extern void RegisterIOSCameraSource();
 


### PR DESCRIPTION
This improves the behavior with multiple cameras/instances of the plugin.