### PR TITLE
Change connection limiting to timeout

### DIFF
--- a/deps/portal/src/Device.cpp
+++ b/deps/portal/src/Device.cpp
@@ -73,11 +73,12 @@ namespace portal
         return _device.product_id;
     }
 
-    int Device::connect(uint16_t port, std::shared_ptr<ChannelDelegate> newChannelDelegate, int attempts)
+    int Device::connect(uint16_t port, std::shared_ptr<ChannelDelegate> newChannelDelegate, int connectTimeoutMs)
     {
         int retval = 0;
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(connectTimeoutMs);
 
-        while (attempts-- > 0) {
+        while (std::chrono::steady_clock::now() < deadline) {
             int conn = usbmuxd_connect(_device.handle, port);
 
             if (conn > 0)

--- a/deps/portal/src/Device.cpp
+++ b/deps/portal/src/Device.cpp
@@ -76,18 +76,19 @@ namespace portal
     int Device::connect(uint16_t port, std::shared_ptr<ChannelDelegate> newChannelDelegate, int attempts)
     {
         int retval = 0;
-        int conn = usbmuxd_connect(_device.handle, port);
 
-        if (conn > 0)
-        {
-            connectedChannel = std::shared_ptr<Channel>(new Channel(port, conn));
-            connectedChannel->configureProtocolDelegate();
-            connectedChannel->setDelegate(newChannelDelegate);
-        } else {
+        while (attempts-- > 0) {
+            int conn = usbmuxd_connect(_device.handle, port);
 
-            if (attempts > 0) {
-                connect(port, newChannelDelegate, attempts - 1);
+            if (conn > 0)
+            {
+                connectedChannel = std::shared_ptr<Channel>(new Channel(port, conn));
+                connectedChannel->configureProtocolDelegate();
+                connectedChannel->setDelegate(newChannelDelegate);
+                return 0;
             }
+
+            retval = conn;
         }
 
         return retval;

--- a/deps/portal/src/Portal.cpp
+++ b/deps/portal/src/Portal.cpp
@@ -72,7 +72,7 @@ namespace portal
         portal_log("PORTAL (%p): Connecting to device: %s (%s)\n", this, device->getProductId().c_str(), device->uuid().c_str());
 
         // Connect to the device with the channel delegate.
-        device->connect(2345, shared_from_this(), 600);
+        device->connect(2345, shared_from_this(), 1200);
     }
 
     void Portal::removeDisconnectedDevices()

--- a/deps/portal/src/Portal.cpp
+++ b/deps/portal/src/Portal.cpp
@@ -72,7 +72,7 @@ namespace portal
         portal_log("PORTAL (%p): Connecting to device: %s (%s)\n", this, device->getProductId().c_str(), device->uuid().c_str());
 
         // Connect to the device with the channel delegate.
-        device->connect(2345, shared_from_this(), 2000);
+        device->connect(2345, shared_from_this(), 600);
     }
 
     void Portal::removeDisconnectedDevices()

--- a/deps/portal/src/Portal.cpp
+++ b/deps/portal/src/Portal.cpp
@@ -72,7 +72,7 @@ namespace portal
         portal_log("PORTAL (%p): Connecting to device: %s (%s)\n", this, device->getProductId().c_str(), device->uuid().c_str());
 
         // Connect to the device with the channel delegate.
-        device->connect(2345, shared_from_this(), 1200);
+        device->connect(2345, shared_from_this(), 200);
     }
 
     void Portal::removeDisconnectedDevices()


### PR DESCRIPTION
I experienced many issues with OBS hanging for many seconds (20 or more) when opening if I had an iPhone connected that was locked.

Instead of trying to connect 2,000 times, this uses a timeout (set to 200ms) when trying to reconnect. It resolves the issue I saw with starting OBS.