### PR TITLE
Add thread safety to VideoToolbox decoder

### DIFF
--- a/src/VideoToolboxVideoDecoder.h
+++ b/src/VideoToolboxVideoDecoder.h
@@ -65,6 +65,7 @@ private:
     std::vector<char> ppsData;
     
     WorkQueue<PacketItem *> mQueue;
+    std::mutex mMutex;
     
     obs_source_frame frame;
 };


### PR DESCRIPTION
Add thread safety to VideoToolbox to try to prevent crashes.