### PR TITLE
Instead of getting the clock again just use the cur_time

### DIFF
--- a/src/FFMpegVideoDecoder.cpp
+++ b/src/FFMpegVideoDecoder.cpp
@@ -83,7 +83,7 @@ void FFMpegVideoDecoder::processPacketItem(PacketItem *packetItem)
 
     auto packet = packetItem->getPacket();
     unsigned char *data = (unsigned char *)packet.data();
-    long long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    long long ts = cur_time;
 
     if (packetItem->getType() == 101) {
 


### PR DESCRIPTION
I noticed that there was already a system clock that we had fetched and it seemed like it was worth using it.