### PR TITLE
Increase recv timeout from 10ms to 100ms to reduce potential spinning

### DIFF
--- a/deps/portal/src/Channel.cpp
+++ b/deps/portal/src/Channel.cpp
@@ -76,7 +76,7 @@ namespace portal
 
             char buffer[numberOfBytesToAskFor];
 
-            int ret = usbmuxd_recv_timeout(conn, (char *)&buffer, numberOfBytesToAskFor, &numberOfBytesReceived, 10);
+            int ret = usbmuxd_recv_timeout(conn, (char *)&buffer, numberOfBytesToAskFor, &numberOfBytesReceived, 100);
 
             if (ret == 0)
             {


### PR DESCRIPTION
If each frame is coming in at 1/30th of a second, it would be sending a packet every 33ms, so a 10ms timeout would cause two recv timeouts before it gets new data.