### PR TITLE
Reduce video frame queue to 5 packets

### DIFF
--- a/src/FFMpegAudioDecoder.cpp
+++ b/src/FFMpegAudioDecoder.cpp
@@ -116,7 +116,10 @@ void *FFMpegAudioDecoder::run() {
 
             if (queueSize > 25) {
                 while (mQueue.size() > 5) {
-                    mQueue.remove();
+                    PacketItem *item = (PacketItem *)mQueue.remove();
+                    if (item != NULL) {
+                        delete item;
+                    }
                 }
             }
         }

--- a/src/Queue.hpp
+++ b/src/Queue.hpp
@@ -43,6 +43,10 @@ public:
     int getTag() {
         return mTag;
     }
+
+    int size() {
+        return mPacket.size();
+    }
 };
 
 template <typename T> class WorkQueue

--- a/src/VideoToolboxVideoDecoder.h
+++ b/src/VideoToolboxVideoDecoder.h
@@ -23,6 +23,7 @@
 
 #include <VideoToolbox/VideoToolbox.h>
 
+#include "obs-ios-camera-source.h"
 #include "Queue.hpp"
 #include "Thread.hpp"
 #include "VideoDecoder.h"


### PR DESCRIPTION
This will hopefully prevent video lag. I've been running into many issues with lag over extended uses and I was hoping this would help.

Also, this solves potential memory leaks that happen when packets are dropped.