### PR TITLE
Fix issue where switching scenes would cause reconnects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
   windows:
     name: "Windows 32/64-bit"
     environment: production
-    runs-on: [windows-latest]
+    runs-on: [windows-2019]
     if: contains(github.event.head_commit.message, '[skip ci]') != true
     env:
       QT_CACHE_VERSION: "2" # Change whenever updating OBS dependencies URL, in order to force a cache reset

--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.9.0"
+#define IOS_CAMERA_PLUGIN_VERSION "2.9.1"
 
 extern void RegisterIOSCameraSource();
 

--- a/src/obs-ios-camera-source.h
+++ b/src/obs-ios-camera-source.h
@@ -53,7 +53,7 @@ public:
 	void setDeviceUUID(std::string uuid);
 	void reconnectToDevice();
 	void resetDecoder();
-	void connectToDevice();
+	void connectToDevice(bool force);
 
 	struct MobileCameraDevice {
 		std::string uuid;


### PR DESCRIPTION
This would happen regardless of whether the device or plugin were in the next scene. If there was an iOS Camera input that was duplicated in two scenes, then the plugin would disconnect and reconnect during a scene switch. This occasionally caused issues where the device would fail to reconnect.