### PR TITLE
Add Linux build and installation support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,5 +27,7 @@ jobs:
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build
         run: cmake --build build --parallel 2
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
       - name: Check linkage
         run: ldd -r build/obs-ios-camera-source.so

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,31 @@
+name: Linux build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            build-essential \
+            cmake \
+            libavcodec-dev \
+            libavutil-dev \
+            libimobiledevice-dev \
+            libobs-dev \
+            libusbmuxd-dev \
+            pkg-config
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - name: Build
+        run: cmake --build build --parallel 2
+      - name: Check linkage
+        run: ldd -r build/obs-ios-camera-source.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.16...4.4)
 project(obs-ios-camera-source)
 
 set(CMAKE_PREFIX_PATH "${QTDIR}")
@@ -7,13 +7,21 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_CXX_STANDARD 17)
 
-if (WIN32 OR APPLE)
+set(LINUX_BUILD FALSE)
+if(UNIX AND NOT APPLE)
+	set(LINUX_BUILD TRUE)
+	set(CMAKE_AUTOMOC OFF)
+	set(CMAKE_AUTOUIC OFF)
+	find_package(libobs CONFIG REQUIRED)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavcodec libavutil)
+	pkg_check_modules(IMOBILEDEVICE REQUIRED IMPORTED_TARGET libimobiledevice-1.0)
+	pkg_check_modules(USBMUXD REQUIRED IMPORTED_TARGET libusbmuxd-2.0)
+else()
     include(external/FindLibObs.cmake)
+    find_package(LibObs REQUIRED)
+    find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil)
 endif()
-
-find_package(LibObs REQUIRED)
-
-find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil)
 # find_ffmpeg_library(avcodec)
 # find_ffmpeg_library(avutil)
 
@@ -30,6 +38,8 @@ if(WIN32)
 	set(DIRENT_DIR "deps/dirent/")
 	cmake_path(ABSOLUTE_PATH DIRENT_DIR OUTPUT_VARIABLE DIRENT_DIR)
 endif()
+
+if(NOT LINUX_BUILD)
 
 # ---- libcnary
 
@@ -202,6 +212,35 @@ target_link_libraries(portal
 	libimobiledevice
 )
 
+else()
+
+set(portal_HEADERS
+	deps/portal/src/Channel.hpp
+	deps/portal/src/Device.hpp
+	deps/portal/src/Protocol.hpp
+	deps/portal/src/logging.h
+	deps/portal/src/DeviceConnection.hpp
+	deps/portal/src/DeviceManager.hpp
+)
+
+set(portal_SOURCES
+	deps/portal/src/Channel.cpp
+	deps/portal/src/Device.cpp
+	deps/portal/src/Protocol.cpp
+	deps/portal/src/DeviceConnection.cpp
+	deps/portal/src/DeviceManager.cpp
+)
+
+add_library(portal STATIC ${portal_SOURCES} ${portal_HEADERS})
+set_target_properties(portal PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(portal PUBLIC deps/portal/src)
+target_link_libraries(portal PUBLIC
+	PkgConfig::IMOBILEDEVICE
+	PkgConfig::USBMUXD
+)
+
+endif()
+
 ## -- 
 
 set(ENABLE_PROGRAMS false)
@@ -283,11 +322,20 @@ if(MSVC)
 endif()
 
 
-target_link_libraries(obs-ios-camera-source 
-	libobs
-	portal
-	${FFMPEG_LIBRARIES}
-)
+if(LINUX_BUILD)
+	target_link_libraries(obs-ios-camera-source
+		OBS::libobs
+		portal
+		PkgConfig::FFMPEG
+	)
+	set_target_properties(obs-ios-camera-source PROPERTIES PREFIX "")
+else()
+	target_link_libraries(obs-ios-camera-source
+		libobs
+		portal
+		${FFMPEG_LIBRARIES}
+	)
+endif()
  
 # --- End of section ---
 
@@ -401,3 +449,27 @@ if(APPLE)
 		${COCOA})
 endif()
 # -- End of section --
+
+if(LINUX_BUILD)
+	include(GNUInstallDirs)
+	install(TARGETS obs-ios-camera-source
+		LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/obs-plugins")
+	install(DIRECTORY data/
+		DESTINATION "${CMAKE_INSTALL_DATADIR}/obs/obs-plugins/obs-ios-camera-source")
+
+	set(OBS_USER_PLUGIN_ROOT
+		"$ENV{HOME}/.config/obs-studio/plugins/obs-ios-camera-source"
+		CACHE PATH "Per-user OBS plugin bundle directory")
+	add_custom_target(install-user
+		COMMAND "${CMAKE_COMMAND}" -E make_directory
+			"${OBS_USER_PLUGIN_ROOT}/bin/64bit"
+			"${OBS_USER_PLUGIN_ROOT}/data"
+		COMMAND "${CMAKE_COMMAND}" -E copy
+			"$<TARGET_FILE:obs-ios-camera-source>"
+			"${OBS_USER_PLUGIN_ROOT}/bin/64bit/"
+		COMMAND "${CMAKE_COMMAND}" -E copy_directory
+			"${CMAKE_CURRENT_SOURCE_DIR}/data"
+			"${OBS_USER_PLUGIN_ROOT}/data"
+		DEPENDS obs-ios-camera-source
+		COMMENT "Installing obs-ios-camera-source for the current user")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,7 @@ endif()
 
 if(LINUX_BUILD)
 	include(GNUInstallDirs)
+	include(CTest)
 	install(TARGETS obs-ios-camera-source
 		LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/obs-plugins")
 	install(DIRECTORY data/
@@ -472,4 +473,15 @@ if(LINUX_BUILD)
 			"${OBS_USER_PLUGIN_ROOT}/data"
 		DEPENDS obs-ios-camera-source
 		COMMENT "Installing obs-ios-camera-source for the current user")
+
+	if(BUILD_TESTING)
+		add_executable(codec-detection-test
+			tests/codec-detection.c
+			src/ffmpeg-decode.c)
+		target_include_directories(codec-detection-test PRIVATE src)
+		target_link_libraries(codec-detection-test PRIVATE
+			OBS::libobs
+			PkgConfig::FFMPEG)
+		add_test(NAME codec-detection COMMAND codec-detection-test)
+	endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -13,6 +13,31 @@ This plugin pairs with the [accompanying iOS app](https://obs.camera/) to begin 
 
 Binaries for Windows and Mac are available in the [Releases](https://github.com/wtsnz/obs-ios-camera-source/releases) section.
 
+## Linux build
+
+Linux builds use the system copies of OBS, FFmpeg, libimobiledevice, and
+libusbmuxd. Install their development packages, along with CMake, a C++17
+compiler, and pkg-config. Then run:
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build --parallel
+```
+
+Install the plugin for the current user without root access:
+
+```sh
+cmake --build build --target install-user
+```
+
+Restart OBS, add an **iOS Camera** source, connect and unlock the iPhone, and
+accept the trust prompt if one appears. The accompanying iOS app must be
+running. Device discovery can be checked independently with `idevice_id -l`.
+
+For distribution packaging or a system-wide install, use the standard CMake
+install target instead. Its destinations respect `CMAKE_INSTALL_PREFIX` and
+the GNU installation directory variables.
+
 
 ## Special thanks
 

--- a/deps/portal/src/Channel.cpp
+++ b/deps/portal/src/Channel.cpp
@@ -31,8 +31,7 @@ Channel::Channel(int port_, int conn_)
 
 Channel::~Channel()
 {
-	running = false;
-	WaitForInternalThreadToExit();
+	close();
 	portal_log("%s: Deallocating\n", __func__);
 }
 
@@ -60,7 +59,12 @@ bool Channel::close()
 		WaitForInternalThreadToExit();
 	}
 
-	auto ret = usbmuxd_disconnect(conn);
+	int ret = 0;
+	if (conn >= 0) {
+		ret = usbmuxd_disconnect(conn);
+		conn = -1;
+	}
+	setState(State::Disconnected);
 
 	return ret;
 }

--- a/deps/portal/src/Channel.hpp
+++ b/deps/portal/src/Channel.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <thread>
+#include <atomic>
 #include <mutex>
 #include <usbmuxd.h>
 

--- a/deps/portal/src/Device.cpp
+++ b/deps/portal/src/Device.cpp
@@ -29,11 +29,12 @@ Device::Device(const usbmuxd_device_info_t &device)
 	  _uuid(_device.udid),
 	  _productId(std::to_string(_device.product_id))
 {
-	portal_log("Added %p to device list\n", this);
+	portal_log("Added %p to device list\n", static_cast<void *>(this));
 }
 
 Device::Device(const Device &other)
-	: _connected(other._connected),
+	: std::enable_shared_from_this<Device>(),
+	  _connected(other._connected),
 	  _device(other._device),
 	  _uuid(other._uuid)
 {
@@ -126,7 +127,7 @@ Device::~Device()
 {
 	disconnect();
 	//removeFromDeviceList();
-	portal_log("Removed %p from device list\n", this);
+	portal_log("Removed %p from device list\n", static_cast<void *>(this));
 }
 
 std::ostream &operator<<(std::ostream &os, const Device &v)

--- a/deps/portal/src/DeviceConnection.cpp
+++ b/deps/portal/src/DeviceConnection.cpp
@@ -37,6 +37,7 @@ DeviceConnection::DeviceConnection(Device::shared_ptr device, int port)
 
 DeviceConnection::~DeviceConnection()
 {
+    disconnect();
     portal_log("%s: Deallocating\n", __func__);
 }
 
@@ -51,7 +52,6 @@ bool DeviceConnection::connect()
 	setState(State::Connecting);
 
 	auto connectTimeoutMs = 200;
-	int retval = 0;
 	auto deadline = std::chrono::steady_clock::now() +
 			std::chrono::milliseconds(connectTimeoutMs);
 
@@ -66,7 +66,6 @@ bool DeviceConnection::connect()
 			channel->start();
 			return 0;
 		}
-		retval = socketHandle;
 	}
 
 	setState(State::FailedToConnect);
@@ -76,14 +75,13 @@ bool DeviceConnection::connect()
 
 bool DeviceConnection::disconnect() 
 {
-    if (getState() != State::Connected) {
+    if (!channel) {
+        setState(State::Disconnected);
         return false;
     }
 
     auto ret = channel->close();
-    if (ret == 0) {
-        channel = nullptr; // Dealloc the channel
-    }
+    channel = nullptr;
 
     setState(State::Disconnected);
 
@@ -122,7 +120,7 @@ void DeviceConnection::channelDidReceiveData(std::vector<char> data)
 }
 
 
-void DeviceConnection::channelDidReceivePacket(std::vector<char> packet, int type, int tag)
+void DeviceConnection::channelDidReceivePacket(std::vector<char>, int, int)
 {
 
 }

--- a/deps/portal/src/DeviceManager.cpp
+++ b/deps/portal/src/DeviceManager.cpp
@@ -18,6 +18,7 @@
 
 #include "DeviceManager.hpp"
 #include <algorithm>
+#include <cstring>
 #include <set>
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
@@ -53,12 +54,7 @@ DeviceManager::DeviceManager()
 
 DeviceManager::~DeviceManager()
 {
-	worker_stopping = true;
-	worker_condition.notify_all();
-
-	if (worker_thread.joinable()) {
-		worker_thread.join();
-	}
+	stop();
 }
 
 void DeviceManager::worker_loop()
@@ -98,6 +94,9 @@ void DeviceManager::updateDevices()
 			changed_devices = true;
 		}
 	}
+	if (device_list) {
+		usbmuxd_device_list_free(&device_list);
+	}
 
 	// Remove any devices that are no longer connected
 	auto devices_copy = devices;
@@ -124,6 +123,7 @@ bool DeviceManager::start()
 		return false;
 	}
 
+	worker_stopping = false;
 	updateDevices();
 
 	setState(State::Connected);
@@ -135,12 +135,11 @@ bool DeviceManager::start()
 
 bool DeviceManager::stop()
 {
-	if (getState() != State::Connected) {
-		return false;
+	worker_stopping = true;
+	worker_condition.notify_all();
+	if (worker_thread.joinable()) {
+		worker_thread.join();
 	}
-
-	//Always returns 0
-	//usbmuxd_unsubscribe();
 
 	setState(State::Disconnected);
 
@@ -224,13 +223,13 @@ bool DeviceManager::addDevice(const usbmuxd_device_info_t &device)
 void DeviceManager::removeDevice(const usbmuxd_device_info_t &device)
 {
 	DeviceMap::iterator it = devices.find(device.udid);
-	auto sp = it->second;
-
-	if (it != devices.end()) {
-		devices.erase(it);
-		portal_log("PORTAL (%p): Removed device: %i (%s)\n", this,
-			   device.product_id, device.udid);
+	if (it == devices.end()) {
+		return;
 	}
+	auto sp = it->second;
+	devices.erase(it);
+	portal_log("PORTAL (%p): Removed device: %i (%s)\n",
+		   static_cast<void *>(this), device.product_id, device.udid);
 
 	if (onDeviceManagerDidRemoveDeviceCallback) {
 		onDeviceManagerDidRemoveDeviceCallback(sp);

--- a/deps/portal/src/DeviceManager.hpp
+++ b/deps/portal/src/DeviceManager.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <thread>
+#include <atomic>
 #include <condition_variable>
 #include <functional>
 

--- a/deps/portal/src/Protocol.cpp
+++ b/deps/portal/src/Protocol.cpp
@@ -17,10 +17,13 @@
  */
 
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 
 #ifdef WIN32
 #include <winsock2.h>
+#else
+#include <arpa/inet.h>
 #endif
 
 #include "Protocol.hpp"
@@ -51,16 +54,12 @@ SimpleDataPacketProtocol::processData(std::vector<char> data)
 
 	auto packets = std::vector<DataPacket>();
 
-	uint32_t length = 0;
-
 	while (buffer.size() >= headerLength) {
 
 		// Read the portal frame out
 		_PortalFrame frame;
 
 		memcpy(&frame, &buffer[0], sizeof(_PortalFrame));
-		length = ntohl(length);
-
 		frame.version = ntohl(frame.version);
 		frame.type = ntohl(frame.type);
 		frame.tag = ntohl(frame.tag);

--- a/deps/portal/src/Protocol.hpp
+++ b/deps/portal/src/Protocol.hpp
@@ -20,6 +20,7 @@
 #define PORTAL_SIMPLE_DATA_PACKET_PROTOCOL_H
 
 #include <vector>
+#include <memory>
 
 #include "logging.h"
 
@@ -73,4 +74,3 @@ class SimpleDataPacketProtocol
     } // namespace portal
 
 #endif
-

--- a/src/FFMpegAudioDecoder.cpp
+++ b/src/FFMpegAudioDecoder.cpp
@@ -40,7 +40,12 @@ void FFMpegAudioDecoder::Init()
 
 void FFMpegAudioDecoder::Flush()
 {
-    // Clear the queue
+    while (mQueue.size() > 0) {
+        auto *item = mQueue.remove();
+        delete item;
+    }
+    std::lock_guard<std::mutex> lock(mMutex);
+    ffmpeg_decode_flush(audio_decoder);
 }
 
 void FFMpegAudioDecoder::Drain()
@@ -63,6 +68,7 @@ void FFMpegAudioDecoder::Input(std::vector<char> packet, int type, int tag)
 
 void FFMpegAudioDecoder::processPacketItem(PacketItem *packetItem)
 {
+    std::lock_guard<std::mutex> lock(mMutex);
     uint64_t cur_time = os_gettime_ns();
 
     if (!ffmpeg_decode_valid(audio_decoder))
@@ -79,21 +85,24 @@ void FFMpegAudioDecoder::processPacketItem(PacketItem *packetItem)
 
     if (packetItem->getType() == 102) {
 
-        bool got_output;
-
-        bool success = ffmpeg_decode_audio(audio_decoder, data, packet.size(), &audio_frame, &got_output);
-
-        if (!success)
-        {
-            blog(LOG_WARNING, "Error decoding audio");
-            return;
-        }
-
-        if (got_output && source != NULL)
-        {
-            audio_frame.timestamp = cur_time;
-            obs_source_output_audio(source, &audio_frame);
-        }
+        bool first = true;
+        bool emitted = false;
+        bool got_output = false;
+        do {
+            bool success = ffmpeg_decode_audio(
+                audio_decoder, first ? data : nullptr,
+                first ? packet.size() : 0, &audio_frame, &got_output);
+            first = false;
+            if (!success) {
+                blog(LOG_WARNING, "Error decoding audio packet");
+                return;
+            }
+            if (got_output && source != NULL) {
+                audio_frame.timestamp = emitted ? os_gettime_ns() : cur_time;
+                obs_source_output_audio(source, &audio_frame);
+                emitted = true;
+            }
+        } while (got_output);
     }
 }
 

--- a/src/FFMpegAudioDecoder.h
+++ b/src/FFMpegAudioDecoder.h
@@ -68,5 +68,7 @@ private:
     obs_source_audio audio_frame;
     
     AudioDecoder audio_decoder;
+
+    std::mutex mMutex;
     
 };

--- a/src/FFMpegVideoDecoder.cpp
+++ b/src/FFMpegVideoDecoder.cpp
@@ -88,13 +88,29 @@ void FFMpegVideoDecoder::processPacketItem(PacketItem *packetItem)
 		const enum AVCodecID codec = detected_codec != AV_CODEC_ID_NONE
 						      ? detected_codec
 						      : AV_CODEC_ID_H264;
-		if (ffmpeg_decode_init(video_decoder, codec) < 0) {
+		int result;
+		if (codec == AV_CODEC_ID_HEVC) {
+			result = ffmpeg_decode_init_hardware(
+				video_decoder, codec, AV_HWDEVICE_TYPE_CUDA);
+		} else {
+			result = ffmpeg_decode_init(video_decoder, codec);
+		}
+
+		if (result < 0) {
 			blog(LOG_WARNING, "Could not initialize %s video decoder",
 			     avcodec_get_name(codec));
 			return;
 		}
-		blog(LOG_INFO, "FFmpeg: initialized %s video decoder",
-		     avcodec_get_name(codec));
+		if (video_decoder->hardware_active) {
+			blog(LOG_INFO,
+			     "FFmpeg: initialized %s video decoder using %s hardware acceleration",
+			     avcodec_get_name(codec),
+			     av_hwdevice_get_type_name(
+				     video_decoder->hardware_device_type));
+		} else {
+			blog(LOG_INFO, "FFmpeg: initialized %s software video decoder",
+			     avcodec_get_name(codec));
+		}
 	}
 
     if (packetItem->getType() == 101) {
@@ -110,8 +126,20 @@ void FFMpegVideoDecoder::processPacketItem(PacketItem *packetItem)
 				&got_output);
 			first = false;
 			if (!success) {
-				blog(LOG_WARNING, "Error decoding %s video packet",
-				     avcodec_get_name(video_decoder->codec->id));
+				const bool hardware_failed =
+					video_decoder->hardware_active;
+				blog(LOG_WARNING,
+				     "Error decoding %s video packet%s",
+				     avcodec_get_name(video_decoder->codec->id),
+				     hardware_failed
+					     ? "; falling back to software"
+					     : "");
+				if (hardware_failed) {
+					const enum AVCodecID codec =
+						video_decoder->codec->id;
+					ffmpeg_decode_free(video_decoder);
+					ffmpeg_decode_init(video_decoder, codec);
+				}
 				break;
 			}
 			if (got_output && source != nullptr) {

--- a/src/FFMpegVideoDecoder.cpp
+++ b/src/FFMpegVideoDecoder.cpp
@@ -41,13 +41,11 @@ void FFMpegVideoDecoder::Flush()
 {
     // Clear the queue
     while(this->mQueue.size() > 0) {
-        this->mQueue.remove();
+        delete this->mQueue.remove();
     }
 
-    mMutex.lock();
-    // Re-initialize the decoder
-    ffmpeg_decode_free(video_decoder);
-    mMutex.unlock();
+    std::lock_guard<std::mutex> lock(mMutex);
+    ffmpeg_decode_flush(video_decoder);
 }
 
 void FFMpegVideoDecoder::Drain()
@@ -71,41 +69,61 @@ void FFMpegVideoDecoder::Input(std::vector<char> packet, int type, int tag)
 static const char *ffmpeg_decode_video_name = "obs_camera_ffmpeg_decode_video";
 void FFMpegVideoDecoder::processPacketItem(PacketItem *packetItem)
 {
-	mMutex.lock();
-	uint64_t cur_time = os_gettime_ns();
-	if (!ffmpeg_decode_valid(video_decoder)) {
-		if (ffmpeg_decode_init(video_decoder, AV_CODEC_ID_H264) < 0) {
-			blog(LOG_WARNING, "Could not initialize video decoder");
-			mMutex.unlock();
-			return;
-		}
-	}
-
+	std::lock_guard<std::mutex> lock(mMutex);
 	auto packet = packetItem->getPacket();
 	unsigned char *data = (unsigned char *)packet.data();
-	long long ts = cur_time;
+	const enum AVCodecID detected_codec =
+		ffmpeg_detect_video_codec(data, packet.size());
+
+	if (ffmpeg_decode_valid(video_decoder) &&
+	    detected_codec != AV_CODEC_ID_NONE &&
+	    video_decoder->codec->id != detected_codec) {
+		blog(LOG_INFO, "FFmpeg: switching video decoder from %s to %s",
+		     avcodec_get_name(video_decoder->codec->id),
+		     avcodec_get_name(detected_codec));
+		ffmpeg_decode_free(video_decoder);
+	}
+
+	if (!ffmpeg_decode_valid(video_decoder)) {
+		const enum AVCodecID codec = detected_codec != AV_CODEC_ID_NONE
+						      ? detected_codec
+						      : AV_CODEC_ID_H264;
+		if (ffmpeg_decode_init(video_decoder, codec) < 0) {
+			blog(LOG_WARNING, "Could not initialize %s video decoder",
+			     avcodec_get_name(codec));
+			return;
+		}
+		blog(LOG_INFO, "FFmpeg: initialized %s video decoder",
+		     avcodec_get_name(codec));
+	}
 
     if (packetItem->getType() == 101) {
         profile_start(ffmpeg_decode_video_name);
 
-        bool got_output;
-        bool success = ffmpeg_decode_video(video_decoder, data, packet.size(), &ts,
-                                           &video_frame, &got_output);
+		bool first = true;
+		bool got_output = false;
+		do {
+			long long ts = (long long)os_gettime_ns();
+			bool success = ffmpeg_decode_video(
+				video_decoder, first ? data : nullptr,
+				first ? packet.size() : 0, &ts, &video_frame,
+				&got_output);
+			first = false;
+			if (!success) {
+				blog(LOG_WARNING, "Error decoding %s video packet",
+				     avcodec_get_name(video_decoder->codec->id));
+				break;
+			}
+			if (got_output && source != nullptr) {
+				video_frame.timestamp = ts >= 0
+							? (uint64_t)ts
+							: os_gettime_ns();
+				obs_source_output_video(source, &video_frame);
+			}
+		} while (got_output);
 
-        profile_end(ffmpeg_decode_video_name);
-        if (!success)
-        {
-            blog(LOG_WARNING, "Error decoding video");
-            mMutex.unlock();
-            return;
-        }
-
-		if (got_output && source != nullptr) {
-			video_frame.timestamp = cur_time;
-			obs_source_output_video(source, &video_frame);
-		}
+		profile_end(ffmpeg_decode_video_name);
 	}
-	mMutex.unlock();
 }
 
 void *FFMpegVideoDecoder::run() {
@@ -136,4 +154,3 @@ void *FFMpegVideoDecoder::run() {
     }
     return NULL;
 }
-

--- a/src/Queue.hpp
+++ b/src/Queue.hpp
@@ -20,8 +20,10 @@
 #define WorkQueue_hpp
 
 #include <list>
+#include <atomic>
 #include <mutex>
 #include <condition_variable>
+#include <vector>
 
 class PacketItem
 {

--- a/src/ffmpeg-decode.c
+++ b/src/ffmpeg-decode.c
@@ -71,6 +71,42 @@ void ffmpeg_decode_free(struct ffmpeg_decode *decode)
     memset(decode, 0, sizeof(*decode));
 }
 
+void ffmpeg_decode_flush(struct ffmpeg_decode *decode)
+{
+    if (decode->decoder)
+        avcodec_flush_buffers(decode->decoder);
+}
+
+enum AVCodecID ffmpeg_detect_video_codec(const uint8_t *data, size_t size)
+{
+    if (!data || size < 5)
+        return AV_CODEC_ID_NONE;
+
+    for (size_t i = 0; i + 4 < size; i++)
+    {
+        size_t header = 0;
+        if (data[i] == 0 && data[i + 1] == 0 && data[i + 2] == 1)
+            header = i + 3;
+        else if (i + 5 < size && data[i] == 0 && data[i + 1] == 0 &&
+                 data[i + 2] == 0 && data[i + 3] == 1)
+            header = i + 4;
+        else
+            continue;
+
+        const uint8_t h264_type = data[header] & 0x1f;
+        const uint8_t hevc_type = (data[header] >> 1) & 0x3f;
+
+        /* Parameter-set NAL units identify the codec without guessing from
+         * slice data, whose type values can overlap between H.264 and HEVC. */
+        if (hevc_type >= 32 && hevc_type <= 34)
+            return AV_CODEC_ID_HEVC;
+        if (h264_type == 7 || h264_type == 8)
+            return AV_CODEC_ID_H264;
+    }
+
+    return AV_CODEC_ID_NONE;
+}
+
 static inline enum video_format convert_pixel_format(int f)
 {
     switch (f)
@@ -163,7 +199,8 @@ static inline void copy_data(struct ffmpeg_decode *decode, uint8_t *data,
     }
 
     memset(decode->packet_buffer + size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
-    memcpy(decode->packet_buffer, data, size);
+    if (size)
+        memcpy(decode->packet_buffer, data, size);
 }
 
 bool ffmpeg_decode_audio(struct ffmpeg_decode *decode,
@@ -249,7 +286,8 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
     packet.size = (int)size;
     packet.pts = *ts;
 
-    if (decode->codec->id == AV_CODEC_ID_H264 && obs_avc_keyframe(data, size))
+    if (data && size && decode->codec->id == AV_CODEC_ID_H264 &&
+        obs_avc_keyframe(data, size))
     {
         packet.flags |= AV_PKT_FLAG_KEY;
     }
@@ -261,7 +299,10 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
             return false;
     }
 
-    ret = avcodec_send_packet(decode->decoder, &packet);
+    if (data && size)
+        ret = avcodec_send_packet(decode->decoder, &packet);
+    else
+        ret = 0;
     if (ret == 0)
         ret = avcodec_receive_frame(decode->decoder, decode->frame);
 

--- a/src/ffmpeg-decode.c
+++ b/src/ffmpeg-decode.c
@@ -25,7 +25,23 @@
 #endif
 #include <obs-avc.h>
 
-int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
+static enum AVPixelFormat select_hardware_format(AVCodecContext *context,
+                                                  const enum AVPixelFormat *formats)
+{
+    struct ffmpeg_decode *decode = context->opaque;
+    for (const enum AVPixelFormat *format = formats;
+         *format != AV_PIX_FMT_NONE; format++)
+    {
+        if (*format == decode->hardware_pixel_format)
+            return *format;
+    }
+
+    return formats[0];
+}
+
+static int ffmpeg_decode_init_internal(struct ffmpeg_decode *decode,
+                                       enum AVCodecID id,
+                                       enum AVHWDeviceType hardware_type)
 {
     int ret;
 
@@ -36,6 +52,36 @@ int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
         return -1;
 
     decode->decoder = avcodec_alloc_context3(decode->codec);
+    if (!decode->decoder)
+        return AVERROR(ENOMEM);
+
+    if (hardware_type != AV_HWDEVICE_TYPE_NONE)
+    {
+        const AVCodecHWConfig *configuration = NULL;
+        for (int index = 0;
+             (configuration = avcodec_get_hw_config(decode->codec, index));
+             index++)
+        {
+            if ((configuration->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
+                configuration->device_type == hardware_type)
+            {
+                decode->hardware_pixel_format = configuration->pix_fmt;
+                break;
+            }
+        }
+
+        if (configuration &&
+            av_hwdevice_ctx_create(&decode->hardware_device, hardware_type,
+                                   NULL, NULL, 0) >= 0)
+        {
+            decode->hardware_device_type = hardware_type;
+            decode->hardware_active = true;
+            decode->decoder->opaque = decode;
+            decode->decoder->get_format = select_hardware_format;
+            decode->decoder->hw_device_ctx =
+                av_buffer_ref(decode->hardware_device);
+        }
+    }
 
     ret = avcodec_open2(decode->decoder, decode->codec, NULL);
     if (ret < 0)
@@ -55,6 +101,18 @@ int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
     return 0;
 }
 
+int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
+{
+    return ffmpeg_decode_init_internal(decode, id, AV_HWDEVICE_TYPE_NONE);
+}
+
+int ffmpeg_decode_init_hardware(struct ffmpeg_decode *decode,
+                                enum AVCodecID id,
+                                enum AVHWDeviceType type)
+{
+    return ffmpeg_decode_init_internal(decode, id, type);
+}
+
 void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 {
     if (decode->decoder)
@@ -64,6 +122,12 @@ void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 
     if (decode->frame)
         av_frame_free(&decode->frame);
+
+    if (decode->software_frame)
+        av_frame_free(&decode->software_frame);
+
+    if (decode->hardware_device)
+        av_buffer_unref(&decode->hardware_device);
 
     if (decode->packet_buffer)
         bfree(decode->packet_buffer);
@@ -273,6 +337,7 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
     AVPacket packet = {0};
     int got_frame = false;
     enum video_format new_format;
+    AVFrame *decoded_frame;
     int ret;
 
     *got_output = false;
@@ -316,13 +381,37 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
     else if (!got_frame)
         return true;
 
-    for (size_t i = 0; i < MAX_AV_PLANES; i++)
+    decoded_frame = decode->frame;
+    if (decode->hardware_active &&
+        decode->frame->format == decode->hardware_pixel_format)
     {
-        frame->data[i] = decode->frame->data[i];
-        frame->linesize[i] = decode->frame->linesize[i];
+        if (!decode->software_frame)
+        {
+            decode->software_frame = av_frame_alloc();
+            if (!decode->software_frame)
+                return false;
+        }
+
+        av_frame_unref(decode->software_frame);
+        ret = av_hwframe_transfer_data(decode->software_frame,
+                                       decode->frame, 0);
+        if (ret < 0)
+            return false;
+
+        ret = av_frame_copy_props(decode->software_frame, decode->frame);
+        if (ret < 0)
+            return false;
+
+        decoded_frame = decode->software_frame;
     }
 
-    new_format = convert_pixel_format(decode->frame->format);
+    for (size_t i = 0; i < MAX_AV_PLANES; i++)
+    {
+        frame->data[i] = decoded_frame->data[i];
+        frame->linesize[i] = decoded_frame->linesize[i];
+    }
+
+    new_format = convert_pixel_format(decoded_frame->format);
     if (new_format != frame->format)
     {
         bool success;
@@ -330,7 +419,7 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
 
         frame->format = new_format;
         frame->full_range =
-        decode->frame->color_range == AVCOL_RANGE_JPEG;
+        decoded_frame->color_range == AVCOL_RANGE_JPEG;
 
         range = frame->full_range ? VIDEO_RANGE_FULL : VIDEO_RANGE_PARTIAL;
 
@@ -346,10 +435,10 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
         }
     }
 
-    *ts = decode->frame->pts;
+    *ts = decoded_frame->pts;
 
-    frame->width = decode->frame->width;
-    frame->height = decode->frame->height;
+    frame->width = decoded_frame->width;
+    frame->height = decoded_frame->height;
     frame->flip = false;
 
     if (frame->format == VIDEO_FORMAT_NONE)

--- a/src/ffmpeg-decode.c
+++ b/src/ffmpeg-decode.c
@@ -16,7 +16,13 @@
  ******************************************************************************/
 
 #include "ffmpeg-decode.h"
+#ifdef __has_include
+#if __has_include("obs-ffmpeg-compat.h")
 #include "obs-ffmpeg-compat.h"
+#endif
+#else
+#include "obs-ffmpeg-compat.h"
+#endif
 #include <obs-avc.h>
 
 int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
@@ -38,8 +44,10 @@ int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
         return ret;
     }
 
-    if (decode->codec->capabilities & CODEC_CAP_TRUNC)
-        decode->decoder->flags |= CODEC_FLAG_TRUNC;
+#if LIBAVCODEC_VERSION_MAJOR < 60
+    if (decode->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
+        decode->decoder->flags |= AV_CODEC_FLAG_TRUNCATED;
+#endif
 
     decode->decoder->flags |= AV_CODEC_FLAG_LOW_DELAY;
     decode->decoder->flags2 = AV_CODEC_FLAG2_CHUNKS;
@@ -51,12 +59,11 @@ void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 {
     if (decode->decoder)
     {
-        avcodec_close(decode->decoder);
-        av_free(decode->decoder);
+        avcodec_free_context(&decode->decoder);
     }
 
     if (decode->frame)
-        av_free(decode->frame);
+        av_frame_free(&decode->frame);
 
     if (decode->packet_buffer)
         bfree(decode->packet_buffer);
@@ -146,7 +153,7 @@ static inline enum speaker_layout convert_speaker_layout(uint8_t channels)
 static inline void copy_data(struct ffmpeg_decode *decode, uint8_t *data,
                              size_t size)
 {
-    size_t new_size = size + INPUT_BUFFER_PADDING_SIZE;
+    size_t new_size = size + AV_INPUT_BUFFER_PADDING_SIZE;
 
     if (decode->packet_size < new_size)
     {
@@ -155,7 +162,7 @@ static inline void copy_data(struct ffmpeg_decode *decode, uint8_t *data,
         decode->packet_size = new_size;
     }
 
-    memset(decode->packet_buffer + size, 0, INPUT_BUFFER_PADDING_SIZE);
+    memset(decode->packet_buffer + size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
     memcpy(decode->packet_buffer, data, size);
 }
 
@@ -172,7 +179,9 @@ bool ffmpeg_decode_audio(struct ffmpeg_decode *decode,
 
     copy_data(decode, data, size);
 
+#if LIBAVCODEC_VERSION_MAJOR < 60
     av_init_packet(&packet);
+#endif
     packet.data = decode->packet_buffer;
     packet.size = (int)size;
 
@@ -204,7 +213,11 @@ bool ffmpeg_decode_audio(struct ffmpeg_decode *decode,
     audio->samples_per_sec = decode->frame->sample_rate;
     audio->format = convert_sample_format(decode->frame->format);
     audio->speakers =
+#if LIBAVUTIL_VERSION_MAJOR >= 57
+    convert_speaker_layout((uint8_t)decode->frame->ch_layout.nb_channels);
+#else
     convert_speaker_layout((uint8_t)decode->decoder->channels);
+#endif
 
     audio->frames = decode->frame->nb_samples;
 
@@ -229,7 +242,9 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
 
     copy_data(decode, data, size);
 
+#if LIBAVCODEC_VERSION_MAJOR < 60
     av_init_packet(&packet);
+#endif
     packet.data = decode->packet_buffer;
     packet.size = (int)size;
     packet.pts = *ts;

--- a/src/ffmpeg-decode.h
+++ b/src/ffmpeg-decode.h
@@ -39,7 +39,11 @@ extern "C" {
 struct ffmpeg_decode
 {
 	AVCodecContext *decoder;
+#if LIBAVCODEC_VERSION_MAJOR >= 59
+	const AVCodec *codec;
+#else
 	AVCodec *codec;
+#endif
 
 	AVFrame *frame;
 

--- a/src/ffmpeg-decode.h
+++ b/src/ffmpeg-decode.h
@@ -53,6 +53,9 @@ struct ffmpeg_decode
 
 extern int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id);
 extern void ffmpeg_decode_free(struct ffmpeg_decode *decode);
+extern void ffmpeg_decode_flush(struct ffmpeg_decode *decode);
+extern enum AVCodecID ffmpeg_detect_video_codec(const uint8_t *data,
+						 size_t size);
 
 extern bool ffmpeg_decode_audio(struct ffmpeg_decode *decode,
 								uint8_t *data, size_t size,

--- a/src/ffmpeg-decode.h
+++ b/src/ffmpeg-decode.h
@@ -30,6 +30,7 @@ extern "C" {
 #endif
 
 #include <libavcodec/avcodec.h>
+#include <libavutil/hwcontext.h>
 #include <libavutil/log.h>
 
 #ifdef _MSC_VER
@@ -46,12 +47,20 @@ struct ffmpeg_decode
 #endif
 
 	AVFrame *frame;
+	AVFrame *software_frame;
+	AVBufferRef *hardware_device;
+	enum AVPixelFormat hardware_pixel_format;
+	enum AVHWDeviceType hardware_device_type;
+	bool hardware_active;
 
 	uint8_t *packet_buffer;
 	size_t packet_size;
 };
 
 extern int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id);
+extern int ffmpeg_decode_init_hardware(struct ffmpeg_decode *decode,
+					       enum AVCodecID id,
+					       enum AVHWDeviceType type);
 extern void ffmpeg_decode_free(struct ffmpeg_decode *decode);
 extern void ffmpeg_decode_flush(struct ffmpeg_decode *decode);
 extern enum AVCodecID ffmpeg_detect_video_codec(const uint8_t *data,

--- a/src/obs-ios-camera-source.cpp
+++ b/src/obs-ios-camera-source.cpp
@@ -122,7 +122,7 @@ void IOSCameraInput::deviceManagerDidUpdateDeviceList(
 void IOSCameraInput::deviceManagerDidChangeState(
 	portal::DeviceManager::State state)
 {
-	blog(LOG_INFO, "deviceManagerDidChangeState %i", state);
+	blog(LOG_INFO, "deviceManagerDidChangeState %i", static_cast<int>(state));
 	std::cout << "DeviceManager::didChangeState: " << state << std::endl;
 }
 
@@ -176,7 +176,19 @@ void IOSCameraInput::deviceManagerDidRemoveDevice(
 
 IOSCameraInput ::~IOSCameraInput()
 {
-
+	deviceManager.onDeviceManagerDidUpdateDeviceListCallback = nullptr;
+	deviceManager.onDeviceManagerDidChangeStateCallback = nullptr;
+	deviceManager.onDeviceManagerDidAddDeviceCallback = nullptr;
+	deviceManager.onDeviceManagerDidRemoveDeviceCallback = nullptr;
+	deviceManager.stop();
+	for (auto &[uuid, controller] : connectionControllers) {
+		UNUSED_PARAMETER(uuid);
+		if (controller) {
+			controller->onProcessPacketCallback = nullptr;
+			controller->disconnect();
+		}
+	}
+	connectionControllers.clear();
 }
 
 void IOSCameraInput::activate()
@@ -302,7 +314,7 @@ void IOSCameraInput::connectToDevice(bool force)
     }
 }
 
-#pragma mark - Settings Config
+// Settings configuration
 
 static bool refresh_devices(obs_properties_t *props, obs_property_t *p,
 			    void *data)
@@ -352,7 +364,7 @@ static bool reconnect_to_device(obs_properties_t *props, obs_property_t *p,
 	return false;
 }
 
-#pragma mark - Plugin Callbacks
+// Plugin callbacks
 
 static const char *GetIOSCameraInputName(void *)
 {
@@ -407,10 +419,10 @@ static obs_properties_t *GetIOSCameraProperties(void *data)
 
 	refresh_devices(ppts, dev_list, data);
 
-	obs_properties_add_button(ppts, "setting_refresh_devices",
-				  "Refresh Devices", refresh_devices);
-	obs_properties_add_button(ppts, "setting_button_connect_to_device",
-				  "Reconnect to Device", reconnect_to_device);
+	obs_properties_add_button2(ppts, "setting_refresh_devices",
+				   "Refresh Devices", refresh_devices, nullptr);
+	obs_properties_add_button2(ppts, "setting_button_connect_to_device",
+				   "Reconnect to Device", reconnect_to_device, nullptr);
 
 	obs_property_t *latency_modes = obs_properties_add_list(
 		ppts, SETTING_PROP_LATENCY,

--- a/tests/codec-detection.c
+++ b/tests/codec-detection.c
@@ -1,6 +1,7 @@
 #include "ffmpeg-decode.h"
 
 #include <assert.h>
+#include <stdlib.h>
 
 int main(void)
 {
@@ -17,6 +18,16 @@ int main(void)
 	assert(ffmpeg_detect_video_codec(unknown, sizeof(unknown)) ==
 	       AV_CODEC_ID_NONE);
 	assert(ffmpeg_detect_video_codec(NULL, 0) == AV_CODEC_ID_NONE);
+
+	if (getenv("REQUIRE_CUDA_HEVC")) {
+		struct ffmpeg_decode decoder = {0};
+		assert(ffmpeg_decode_init_hardware(
+			       &decoder, AV_CODEC_ID_HEVC,
+			       AV_HWDEVICE_TYPE_CUDA) == 0);
+		assert(decoder.hardware_active);
+		assert(decoder.hardware_device_type == AV_HWDEVICE_TYPE_CUDA);
+		ffmpeg_decode_free(&decoder);
+	}
 
 	return 0;
 }

--- a/tests/codec-detection.c
+++ b/tests/codec-detection.c
@@ -1,0 +1,22 @@
+#include "ffmpeg-decode.h"
+
+#include <assert.h>
+
+int main(void)
+{
+	const uint8_t h264_sps[] = {0x00, 0x00, 0x00, 0x01, 0x67, 0x64,
+				    0x00, 0x28};
+	const uint8_t hevc_vps[] = {0x00, 0x00, 0x01, 0x40, 0x01, 0x0c,
+				    0x01};
+	const uint8_t unknown[] = {0x00, 0x00, 0x01, 0x06, 0x05, 0xff};
+
+	assert(ffmpeg_detect_video_codec(h264_sps, sizeof(h264_sps)) ==
+	       AV_CODEC_ID_H264);
+	assert(ffmpeg_detect_video_codec(hevc_vps, sizeof(hevc_vps)) ==
+	       AV_CODEC_ID_HEVC);
+	assert(ffmpeg_detect_video_codec(unknown, sizeof(unknown)) ==
+	       AV_CODEC_ID_NONE);
+	assert(ffmpeg_detect_video_codec(NULL, 0) == AV_CODEC_ID_NONE);
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

- add a Linux CMake path using the system libobs, FFmpeg, libimobiledevice, and libusbmuxd packages
- update the decoder for current FFmpeg while retaining compatibility with older FFmpeg used by the existing builds
- add system-wide and per-user OBS installation targets
- fix missing portable includes and clean up device/connection shutdown behavior
- add an Ubuntu Linux build workflow and Linux documentation

## Validation

- clean build against OBS Studio 32.2.2 and FFmpeg 9 on x86_64 Linux
- `ldd -r` reports no missing libraries or unresolved symbols
- per-user install tested with OBS Studio
- USB video and audio tested successfully with an iPhone and the Camera for OBS Studio app

Related to #26.